### PR TITLE
Propagate image pull policy to buildkit pod

### DIFF
--- a/internal/controllers/buildkit/builder.go
+++ b/internal/controllers/buildkit/builder.go
@@ -60,8 +60,9 @@ func (b *Builder) BuildPod(ctx context.Context) (*corev1.Pod, error) {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  buildkitContainerName,
-					Image: template.Spec.Image,
+					Name:            buildkitContainerName,
+					Image:           template.Spec.Image,
+					ImagePullPolicy: template.Spec.ImagePullPolicy,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "buildkitd",

--- a/internal/controllers/buildkit/builder_test.go
+++ b/internal/controllers/buildkit/builder_test.go
@@ -220,10 +220,11 @@ func TestBuilder_BuildPod(t *testing.T) {
 					PodAnnotations: map[string]string{
 						"template.example.com/config": "enabled",
 					},
-					Rootless:      true,
-					Port:          4567,
-					BuildkitdToml: "[worker.oci]\n  enabled = true\n",
-					Image:         "moby/buildkit:latest",
+					Rootless:        true,
+					Port:            4567,
+					BuildkitdToml:   "[worker.oci]\n  enabled = true\n",
+					Image:           "moby/buildkit:latest",
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Resources: v1alpha1.BuildkitTemplateResources{
 						Maximum: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("2000m"),

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/full_customization.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/full_customization.golden
@@ -43,6 +43,7 @@ spec:
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: service.name=custom-buildkit-service,deployment.environment=ci
     image: moby/buildkit:latest
+    imagePullPolicy: IfNotPresent
     lifecycle:
       preStop:
         exec:


### PR DESCRIPTION
- pass BuildkitTemplate.Spec.ImagePullPolicy through to the buildkit container so pod creation respects configured pull policy
- extend BuildPod test and golden fixture to assert the pull policy is preserved