### PR TITLE
Optimize BuildKit pod probes for faster readiness detection

### DIFF
--- a/internal/controllers/buildkit/builder.go
+++ b/internal/controllers/buildkit/builder.go
@@ -83,15 +83,23 @@ func (b *Builder) BuildPod(ctx context.Context) (*corev1.Pod, error) {
 						},
 					},
 					Resources: resources.WithMaximums(template.Spec.Resources.Maximum, template.Spec.Resources.Default, b.buildkit.Spec.Resources),
+					StartupProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							GRPC: &corev1.GRPCAction{
+								Port: template.Spec.Port,
+							},
+						},
+						PeriodSeconds:    2,
+						FailureThreshold: 15,
+					},
 					ReadinessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							GRPC: &corev1.GRPCAction{
 								Port: template.Spec.Port,
 							},
 						},
-						InitialDelaySeconds: 5,
-						PeriodSeconds:       15,
-						FailureThreshold:    2,
+						PeriodSeconds:    15,
+						FailureThreshold: 2,
 					},
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
@@ -99,10 +107,9 @@ func (b *Builder) BuildPod(ctx context.Context) (*corev1.Pod, error) {
 								Port: template.Spec.Port,
 							},
 						},
-						InitialDelaySeconds: 5,
-						TimeoutSeconds:      3,
-						PeriodSeconds:       30,
-						FailureThreshold:    6,
+						TimeoutSeconds:   3,
+						PeriodSeconds:    30,
+						FailureThreshold: 6,
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: new(true),

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/full_customization.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/full_customization.golden
@@ -55,7 +55,6 @@ spec:
       grpc:
         port: 4567
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -68,7 +67,6 @@ spec:
       grpc:
         port: 4567
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources:
       limits:
@@ -82,6 +80,12 @@ spec:
       runAsUser: 1000
       seccompProfile:
         type: Unconfined
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 4567
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /home/user/.local/share/buildkit
       name: buildkitd

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/hostusers_false.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/hostusers_false.golden
@@ -17,7 +17,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -30,11 +29,16 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources: {}
     securityContext:
       privileged: true
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 1234
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /var/lib/buildkit
       name: buildkitd

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/labels_and_annotations.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/labels_and_annotations.golden
@@ -22,7 +22,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -35,11 +34,16 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources: {}
     securityContext:
       privileged: true
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 1234
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /var/lib/buildkit
       name: buildkitd

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/observability_options.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/observability_options.golden
@@ -30,7 +30,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -43,11 +42,16 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources: {}
     securityContext:
       privileged: true
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 1234
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /var/lib/buildkit
       name: buildkitd

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/requested_resources_exceed_template_defaults.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/requested_resources_exceed_template_defaults.golden
@@ -17,7 +17,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -30,7 +29,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources:
       limits:
@@ -41,6 +39,12 @@ spec:
         memory: 4Gi
     securityContext:
       privileged: true
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 1234
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /var/lib/buildkit
       name: buildkitd

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/rootless.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/rootless.golden
@@ -20,7 +20,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -33,7 +32,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources: {}
     securityContext:
@@ -41,6 +39,12 @@ spec:
       runAsUser: 1000
       seccompProfile:
         type: Unconfined
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 1234
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /home/user/.local/share/buildkit
       name: buildkitd

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/simple_example.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/simple_example.golden
@@ -17,7 +17,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -30,11 +29,16 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources: {}
     securityContext:
       privileged: true
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 1234
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /var/lib/buildkit
       name: buildkitd

--- a/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/with_buildkitd.toml.golden
+++ b/internal/controllers/buildkit/testdata/TestBuilder_BuildPod/with_buildkitd.toml.golden
@@ -17,7 +17,6 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 30
       timeoutSeconds: 3
     name: buildkit
@@ -30,11 +29,16 @@ spec:
       grpc:
         port: 1234
         service: null
-      initialDelaySeconds: 5
       periodSeconds: 15
     resources: {}
     securityContext:
       privileged: true
+    startupProbe:
+      failureThreshold: 15
+      grpc:
+        port: 1234
+        service: null
+      periodSeconds: 2
     volumeMounts:
     - mountPath: /var/lib/buildkit
       name: buildkitd


### PR DESCRIPTION
## Why

BuildKit typically starts in ~1s, but the previous probe configuration had `initialDelaySeconds: 5` on both readiness and liveness probes. This caused CI to sit waiting for BuildKit to be marked ready well after it was actually accepting connections.

This improves the time to readiness from 5-20s to 2-4s 🎉 

## What changed

- **Added a startup probe** (checks every 2s, up to 15 failures = 30s max startup tolerance) to handle the "is the process up yet?" concern and gate the other probes until BuildKit is ready
- **Readiness probe**: dropped `initialDelaySeconds: 5` (startup probe covers the initial delay)
- **Liveness probe**: dropped `initialDelaySeconds: 5` (startup probe covers this)

## Impact

| Scenario | Before | After |
|---|---|---|
| Time to first readiness (typical) | ~5s | ~2s |
| Time to first readiness (worst case) | ~20s | ~4s |
| Max startup tolerance | ~35s | ~30s |
| Liveness restart threshold | ~185s | ~180s |