### PR TITLE
Scope the informer cache to operator-managed Pods and ConfigMaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ kubectl --kubeconfig ./kind/kubeconfig [command]
   - `builder.go`: Template construction logic
   - `conditions.go`: Status condition constants
 
+- **internal/bootstrap/**: Manager startup, mirroring the Achilles SDK's `bootstrap.Start` but with the informer cache scoped (by the SDK's managed-by label) to only the Pods and ConfigMaps this operator manages
+
 - **internal/webhooks/**: Admission webhook handlers
   - `buildkit.go`: Validation webhook for Buildkit resources
   - `buildkit_template.go`: Validation and defaulting webhook for BuildkitTemplate resources

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/reddit/achilles-sdk/pkg/bootstrap"
+	sdkbootstrap "github.com/reddit/achilles-sdk/pkg/bootstrap"
 	"github.com/reddit/achilles-sdk/pkg/fsm/metrics"
 	"github.com/reddit/achilles-sdk/pkg/io"
 	"github.com/reddit/achilles-sdk/pkg/logging"
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	crtMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
+	"github.com/seatgeek/buildkit-operator/internal/bootstrap"
 	"github.com/seatgeek/buildkit-operator/internal/controllers/buildkit"
 	"github.com/seatgeek/buildkit-operator/internal/controllers/buildkit_template"
 	"github.com/seatgeek/buildkit-operator/internal/controlplane"
@@ -30,7 +31,7 @@ import (
 // controllers should run. Typically these are fed values from CLI flags or
 // environment variables.
 type opts struct {
-	bootstrap bootstrap.Options
+	bootstrap sdkbootstrap.Options
 }
 
 const (
@@ -69,9 +70,9 @@ func rootCommand(ctx context.Context) *cobra.Command {
 }
 
 // initStartFunc accepts options that are typically set from CLI flags or
-// environment variables. It returns an instance of [bootstrap.StartFunc],
+// environment variables. It returns an instance of [sdkbootstrap.StartFunc],
 // which can then be fed into [bootstrap.Start].
-func initStartFunc(o *opts) bootstrap.StartFunc {
+func initStartFunc(o *opts) sdkbootstrap.StartFunc {
 	return func(ctx context.Context, mgr manager.Manager) error {
 		meta.InitRedditLabels(ApplicationName, Version, ComponentName)
 

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -60,7 +60,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/iancoleman/strcase v0.3.0 // indirect
+	github.com/iancoleman/strcase v0.3.0
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,0 +1,221 @@
+// Copyright 2026 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+// Package bootstrap starts the controller manager the same way
+// github.com/reddit/achilles-sdk/pkg/bootstrap does, but with the informer
+// cache scoped to the objects this operator manages. The SDK's bootstrap
+// offers no way to configure cache.Options, so its manager caches every Pod
+// and ConfigMap in the cluster, growing the operator's memory footprint with
+// total cluster size rather than with the number of Buildkit instances.
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/go-logr/zapr"
+	"github.com/iancoleman/strcase"
+	sdkbootstrap "github.com/reddit/achilles-sdk/pkg/bootstrap"
+	"github.com/reddit/achilles-sdk/pkg/logging"
+	"github.com/reddit/achilles-sdk/pkg/meta"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	zaputil "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/seatgeek/buildkit-operator/api/v1alpha1"
+)
+
+const (
+	errNoValidKubeContext      = "kubeconfig context must be specified when not in cluster"
+	errKubeContextSetInCluster = "kubeconfig context can not be specified when in cluster"
+)
+
+// Start runs the controller manager. It mirrors
+// [sdkbootstrap.Start] except that the manager is built with [CacheOptions].
+func Start(
+	ctx context.Context,
+	schemes runtime.SchemeBuilder,
+	opts *sdkbootstrap.Options,
+	startFunc sdkbootstrap.StartFunc,
+) error {
+	log := setupLogging(opts.VerboseMode, opts.DevLogger)
+	ctx = logging.NewContext(ctx, log)
+
+	cfg, err := buildRestConfig(opts)
+	if err != nil {
+		return fmt.Errorf("building k8s client config: %w", err)
+	}
+
+	mgr, err := buildManager(cfg, log, schemes, opts)
+	if err != nil {
+		return fmt.Errorf("building manager: %w", err)
+	}
+
+	if err := startFunc(ctx, mgr); err != nil {
+		return fmt.Errorf("running start func: %w", err)
+	}
+
+	log.Info("starting manager")
+	// the signal handler context is deliberately the manager's root context
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil { //nolint:contextcheck
+		return fmt.Errorf("starting manager: %w", err)
+	}
+
+	return nil
+}
+
+// CacheOptions scopes the manager's informer cache for the built-in types the
+// operator watches. The achilles-sdk FSM labels every object it applies with
+// [meta.ManagedByKey] set to the controller's name, so filtering on that
+// label keeps only the operator's own Pods and ConfigMaps in the cache. The
+// Buildkit and BuildkitTemplate CRDs remain unfiltered.
+//
+// A nil syncPeriod uses the controller-runtime default.
+func CacheOptions(syncPeriod *time.Duration) cache.Options {
+	return cache.Options{
+		SyncPeriod: syncPeriod,
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}:       {Label: managedBySelector(v1alpha1.Buildkit{})},
+			&corev1.ConfigMap{}: {Label: managedBySelector(v1alpha1.BuildkitTemplate{})},
+		},
+	}
+}
+
+// managedBySelector matches objects applied by the FSM controller that
+// reconciles the given resource type. The achilles-sdk names each controller
+// as the kebab-cased Kind of its reconciled resource and stamps that name
+// into the [meta.ManagedByKey] label of every object the controller applies.
+func managedBySelector(reconciledType any) labels.Selector { //nolint:ireturn
+	return labels.SelectorFromSet(labels.Set{
+		meta.ManagedByKey: strcase.ToKebab(reflect.TypeOf(reconciledType).Name()),
+	})
+}
+
+//nolint:ireturn
+func buildManager(
+	cfg *rest.Config,
+	log *zap.SugaredLogger,
+	schemes runtime.SchemeBuilder,
+	opts *sdkbootstrap.Options,
+) (manager.Manager, error) {
+	mgr, err := manager.New(
+		cfg,
+		manager.Options{
+			HealthProbeBindAddress:  opts.HealthAddr,
+			Metrics:                 server.Options{BindAddress: opts.MetricsAddr},
+			Logger:                  zapr.NewLogger(log.Desugar()),
+			Cache:                   CacheOptions(&opts.SyncPeriod),
+			LeaderElection:          opts.LeaderElection,
+			LeaderElectionID:        opts.LeaderElectionID,
+			LeaderElectionNamespace: opts.LeaderElectionNamespace,
+			RenewDeadline:           &opts.LeaderElectionRenewDeadline,
+			LeaseDuration:           &opts.LeaderElectionLeaseDuration,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("constructing manager: %w", err)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("adding healthz: %w", err)
+	}
+
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return nil, fmt.Errorf("adding readyz: %w", err)
+	}
+
+	if schemes != nil {
+		if err := schemes.AddToScheme(mgr.GetScheme()); err != nil {
+			return nil, err
+		}
+	}
+	return mgr, nil
+}
+
+func buildRestConfig(o *sdkbootstrap.Options) (*rest.Config, error) {
+	if o.InCluster {
+		if o.KubeContext != "" {
+			return nil, errors.New(errKubeContextSetInCluster)
+		}
+
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("building in-cluster kubeconfig: %w", err)
+		}
+
+		cfg.QPS = o.ClientQPS
+		cfg.Burst = o.ClientBurst
+
+		return cfg, err
+	}
+
+	if o.KubeContext == "" {
+		return nil, errors.New(errNoValidKubeContext)
+	}
+
+	var rules *clientcmd.ClientConfigLoadingRules
+	if o.KubeConfig != "" {
+		rules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: o.KubeConfig}
+	} else {
+		rules = clientcmd.NewDefaultClientConfigLoadingRules()
+	}
+
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules,
+		&clientcmd.ConfigOverrides{
+			CurrentContext: o.KubeContext,
+		},
+	).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.QPS = o.ClientQPS
+	cfg.Burst = o.ClientBurst
+
+	return cfg, nil
+}
+
+func setupLogging(verboseMode, devLogger bool) *zap.SugaredLogger {
+	var baseLogger *zap.Logger
+	if devLogger {
+		l, err := zap.NewDevelopment()
+		if err != nil {
+			panic(err)
+		}
+		baseLogger = l
+	} else {
+		level := zapcore.InfoLevel
+		if verboseMode {
+			level = zapcore.DebugLevel
+		}
+		atomicLevel := zap.NewAtomicLevelAt(level)
+		baseLogger = zaputil.NewRaw(
+			zaputil.Level(&atomicLevel),
+			func(options *zaputil.Options) {
+				options.TimeEncoder = zapcore.ISO8601TimeEncoder
+			},
+		)
+	}
+
+	// controller-runtime requires its global logger to be set before any
+	// controllers are built
+	ctrl.SetLogger(zapr.NewLogger(baseLogger))
+
+	return baseLogger.Sugar()
+}

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 SeatGeek, Inc.
+//
+// Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+
+package bootstrap_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/iancoleman/strcase"
+	"github.com/reddit/achilles-sdk/pkg/meta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/seatgeek/buildkit-operator/api/v1alpha1"
+	"github.com/seatgeek/buildkit-operator/internal/bootstrap"
+	intscheme "github.com/seatgeek/buildkit-operator/internal/scheme"
+)
+
+// TestCacheOptions_SelectorsMatchFSMLabels asserts that the cache label
+// selectors match the labels the achilles-sdk FSM stamps on applied objects:
+// meta.ManagedByKey set to the kebab-cased, scheme-registered Kind of the
+// reconciled resource. If either controller's reconciled type is renamed, or
+// the cache filter drifts from the FSM's labeling, managed objects would
+// become invisible to the operator and it would spawn duplicates.
+func TestCacheOptions_SelectorsMatchFSMLabels(t *testing.T) {
+	t.Parallel()
+
+	scheme := intscheme.MustNewScheme()
+
+	tests := []struct {
+		name           string
+		cachedObject   client.Object
+		reconciledType client.Object
+	}{
+		{
+			name:           "Pods are cached for the Buildkit controller",
+			cachedObject:   &corev1.Pod{},
+			reconciledType: &v1alpha1.Buildkit{},
+		},
+		{
+			name:           "ConfigMaps are cached for the BuildkitTemplate controller",
+			cachedObject:   &corev1.ConfigMap{},
+			reconciledType: &v1alpha1.BuildkitTemplate{},
+		},
+	}
+
+	opts := bootstrap.CacheOptions(nil)
+	require.Len(t, opts.ByObject, len(tests), "every ByObject entry must be covered by a test case")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// ByObject is keyed by example objects; look up by type since the
+			// map keys are pointers
+			var byObject *cache.ByObject
+			for k, v := range opts.ByObject {
+				if reflect.TypeOf(k) == reflect.TypeOf(tc.cachedObject) {
+					byObject = &v
+					break
+				}
+			}
+			require.NotNil(t, byObject, "expected a ByObject entry for %T", tc.cachedObject)
+			require.NotNil(t, byObject.Label)
+
+			// derive the stamped labels exactly as the achilles-sdk FSM does:
+			// controller name = strcase.ToKebab of the scheme-registered Kind
+			gvk, err := apiutil.GVKForObject(tc.reconciledType, scheme)
+			require.NoError(t, err)
+			stamped := meta.RedditLabels(strcase.ToKebab(gvk.Kind))
+
+			assert.True(t, byObject.Label.Matches(labels.Set(stamped)),
+				"selector %q must match FSM-stamped labels %v", byObject.Label, stamped)
+			assert.False(t, byObject.Label.Matches(labels.Set{}),
+				"selector must not match unlabeled objects")
+		})
+	}
+}

--- a/internal/controllers/buildkit/reconciler_suite_test.go
+++ b/internal/controllers/buildkit/reconciler_suite_test.go
@@ -25,6 +25,7 @@ import (
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/seatgeek/buildkit-operator/internal/bootstrap"
 	"github.com/seatgeek/buildkit-operator/internal/controllers/buildkit"
 	"github.com/seatgeek/buildkit-operator/internal/controlplane"
 	intscheme "github.com/seatgeek/buildkit-operator/internal/scheme"
@@ -62,6 +63,9 @@ var _ = BeforeSuite(func() {
 		WithCRDDirectoryPaths(test.CRDPaths()).
 		WithScheme(scheme).
 		WithLog(log.Desugar()).
+		// the production cache filters Pods by label; running tests with the
+		// same cache options proves managed pods stay visible to the operator
+		WithManagerOpts(manager.Options{Cache: bootstrap.CacheOptions(nil)}).
 		WithManagerSetupFns(
 			func(mgr manager.Manager) error {
 				clientApplicator := &io.ClientApplicator{

--- a/internal/controllers/buildkit_template/reconciler_suite_test.go
+++ b/internal/controllers/buildkit_template/reconciler_suite_test.go
@@ -25,6 +25,7 @@ import (
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/seatgeek/buildkit-operator/internal/bootstrap"
 	"github.com/seatgeek/buildkit-operator/internal/controllers/buildkit_template"
 	"github.com/seatgeek/buildkit-operator/internal/controlplane"
 	intscheme "github.com/seatgeek/buildkit-operator/internal/scheme"
@@ -62,6 +63,10 @@ var _ = BeforeSuite(func() {
 		WithCRDDirectoryPaths(test.CRDPaths()).
 		WithScheme(scheme).
 		WithLog(log.Desugar()).
+		// the production cache filters ConfigMaps by label; running tests with
+		// the same cache options proves managed configmaps stay visible to the
+		// operator
+		WithManagerOpts(manager.Options{Cache: bootstrap.CacheOptions(nil)}).
 		WithManagerSetupFns(
 			func(mgr manager.Manager) error {
 				clientApplicator := &io.ClientApplicator{


### PR DESCRIPTION
## Problem

The Achilles SDK's `bootstrap.Start` builds the controller-runtime manager with an unscoped informer cache (`cache.Options` only sets `SyncPeriod`, and `bootstrap.Options` exposes no way to change that). Because the Buildkit controller `Manages()` Pods and the BuildkitTemplate controller `Manages()` ConfigMaps, the leader's cache holds **every Pod and every ConfigMap in the cluster**, not just the ones the operator manages.

On a busy cluster this makes the operator's memory usage proportional to total cluster size rather than to its own workload. We measured live heap growing roughly linearly with cluster-wide pod count and observed repeated OOMKills at CI peak with a 512Mi limit, while the operator only manages a few dozen pods.

## Fix

A new `internal/bootstrap` package mirrors the SDK's `bootstrap.Start`, but builds the manager with `cache.Options.ByObject` label selectors:

- Pods: `infrared.reddit.com/managed-by=buildkit`
- ConfigMaps: `infrared.reddit.com/managed-by=buildkit-template`

These are the labels the Achilles FSM stamps on every object it applies (`meta.SetRedditLabels` in the FSM apply path, with the controller name derived as the kebab-cased Kind of the reconciled resource), so they are present on all objects the operator has ever created and cannot be overridden by user-supplied pod labels. The CRD types remain unfiltered.

This cuts the cached pod set from "every pod in the cluster" to only buildkit pods (~95%+ reduction in our environment) and makes memory track the operator's own workload.

## Safety

The nasty failure mode of a wrong selector would be managed pods becoming invisible to the cache (`Get` returns NotFound → the operator spawns duplicates). Guarded three ways:

- Verified live in-cluster that existing operator-created Pods and ConfigMaps carry the expected labels.
- `TestCacheOptions_SelectorsMatchFSMLabels` asserts the selectors match labels derived exactly the way the SDK derives them (scheme-registered Kind → kebab-case), so a CRD rename or filter drift fails CI.
- Both reconciler envtest suites now run with the same scoped `cache.Options` via `WithManagerOpts`, so every UAT test exercises the create-and-read-back loop through the filtered cache.

## Notes

- The ideal fix is upstream (cache-option passthrough in `achilles-sdk`'s `bootstrap.Options`); this package can shrink to a thin wrapper if/when that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)