### PR TITLE
chore(deps): update Go to v1.26.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM golang:1.26.2-alpine3.23 AS builder
+FROM golang:1.26.7-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.2"
+go = "1.26.7"
 kind = "0.32.0"
 "github:fatedier/frp" = "0.71.0"
 


### PR DESCRIPTION
Bumps the pinned Go toolchain to **1.26.7**, the latest 1.26.x patch release (was 1.26.2).

Two atomic commits, matching how Renovate normally splits these:

- `chore(deps): update dependency go to v1.26.7` — `mise.toml`
- `chore(deps): update golang docker tag to v1.26.7` — `Dockerfile` (Go patch only; `alpine3.23` left as-is)

### Deliberately not changed

- `go.mod`, `api/go.mod`, `go.work` stay at `go 1.26.0`. That directive is a minimum-toolchain floor, not a patch pin — it has only ever moved on minors here (1.24.3 → 1.25.0 → 1.26.0), and raising it would raise the required toolchain for every external consumer of the published `api` module.
- `.github/actions/setup-go/action.yml` stays at `'1.26'`. `actions/setup-go` already resolves that range to the newest patch, so CI picks up 1.26.7 on its own; pinning it would only go stale.

This is a patch bump, so 1.27.0 (now stable) is out of scope.

### Verification

An unfiltered sweep for `1\.26(\.[0-9]+)?` confirms those are the only Go version references in the repo. Locally on go1.26.7: `mise install go` resolves cleanly, and `go build ./...`, `go vet ./...`, and the `api` module build all pass. `make tidy` not needed — the `go` directive didn't move.