### PR TITLE
Support configurable labels and annotations on the operator Deployment

### DIFF
--- a/charts/buildkit-operator/templates/deployment.yaml
+++ b/charts/buildkit-operator/templates/deployment.yaml
@@ -3,12 +3,19 @@ kind: Deployment
 metadata:
   name: {{ include "buildkit-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.operator.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: buildkit-operator
     app.kubernetes.io/part-of: buildkit-operator
     control-plane: controller-manager
     {{- include "buildkit-operator.labels" . | nindent 4 }}
+    {{- with .Values.operator.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/buildkit-operator/values.yaml
+++ b/charts/buildkit-operator/values.yaml
@@ -57,6 +57,13 @@ operator:
   # Additional annotations to apply to the operator pod template
   podAnnotations: {}
 
+  # Additional labels to apply to the operator Deployment
+  # (avoid overriding app.kubernetes.io/* labels; GitOps tools track ownership by them)
+  deploymentLabels: {}
+
+  # Additional annotations to apply to the operator Deployment
+  deploymentAnnotations: {}
+
   # Additional environment variables for the operator
   env: []
 


### PR DESCRIPTION
## What

Adds two Helm values that apply to the operator's own `Deployment` object metadata:

- `operator.deploymentLabels`
- `operator.deploymentAnnotations`

## Why

The chart already exposes `operator.podLabels` and `operator.podAnnotations`, but those land in `spec.template.metadata` — i.e. on the pod, not on the Deployment. There was no way to put metadata on the Deployment object itself, which is what tools like ArgoCD (sync waves, hooks) and Reloader read.

## Notes

- Both keys are guarded with `{{- with }}`, so omitting them renders no empty `annotations:`/`labels:` key.
- `deploymentLabels` writes **only** to `metadata.labels` — `spec.selector.matchLabels` and the pod template are untouched, so this is safe to set on an existing release without hitting an immutable-selector error.
- A comment in `values.yaml` warns against overriding `app.kubernetes.io/*` labels, since GitOps tools track Deployment ownership by them.
- Named `deployment*` rather than a bare `operator.labels`/`operator.annotations` because every unprefixed `operator.*` value in this chart targets the pod or container; the chart already disambiguates object level by prefix (`securityContext` vs `podSecurityContext`, `podLabels` vs the new keys).
- No `Chart.yaml` bump: CI rewrites `version`/`appVersion` from the git ref at publish time.

## Testing

- `helm template` verified for the default (no keys emitted) and set cases, plus edge cases: multi-key maps, multi-line block scalars, dotted/slashed keys, empty strings
- `helm lint` clean
- `./hack/validate-helm-templates.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
